### PR TITLE
feat: Improve commit message for skipped encrypted files

### DIFF
--- a/src/commands/encryptFiles.ts
+++ b/src/commands/encryptFiles.ts
@@ -18,8 +18,12 @@ export const encryptFiles = (config: FullGalacryptConfig) => {
       continue;
     }
     try {
-      encryptFile({ inputPath: file.input, outputPath: file.output, secretKey: config.key });
-      console.log(`Encrypted '${file.input}' to '${file.output}'`);
+      const encrypted = encryptFile({ inputPath: file.input, outputPath: file.output, secretKey: config.key });
+      if (encrypted) {
+        console.log(`Encrypted '${file.input}' to '${file.output}'`);
+      } else {
+        console.log(`Skipped '${file.input}' (already encrypted)`);
+      }
 
       if (shouldGitAdd) {
         execSync(`git add ${file.output}`);

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -45,13 +45,13 @@ const getEncryptedHashIfExists = (path: string) => {
   return lines[1];
 };
 
-export const encryptFile = ({ inputPath, outputPath, secretKey }: FileIoInput) => {
+export const encryptFile = ({ inputPath, outputPath, secretKey }: FileIoInput): boolean => {
   const inputFileContent = fs.readFileSync(inputPath);
   const outputFileHash = getEncryptedHashIfExists(outputPath);
   const inputFileHash = hash(inputFileContent);
 
   if (outputFileHash && outputFileHash === inputFileHash) {
-    return;
+    return false;
   }
 
   const encrypted = encrypt(inputFileContent, secretKey);
@@ -61,6 +61,7 @@ ${encrypted.iv}
 ${encrypted.encryptedData}`;
 
   fs.writeFileSync(outputPath, outputFileContent);
+  return true;
 };
 
 export const decryptFile = ({ inputPath, outputPath, secretKey }: FileIoInput) => {


### PR DESCRIPTION
This commit modifies `encryptFile` to return a boolean indicating whether the file was actually encrypted or skipped. The `encryptFiles` command is updated to log Skipped when a file is already encrypted and Encrypted otherwise. This provides more accurate feedback to the user during the encryption process.